### PR TITLE
Make part of response optional

### DIFF
--- a/schema/DICOM/dicom.wado.ws.2011.xsd
+++ b/schema/DICOM/dicom.wado.ws.2011.xsd
@@ -118,15 +118,15 @@
             <xs:element ref="ihe:RepositoryUniqueId"/>
             <xs:element name="SourceDocumentUniqueId" type="xs:string"/>
             <xs:element ref="FrameNumber" minOccurs="0"/>
-            <xs:element ref="Annotation"/>
-            <xs:element ref="Rows"/>
-            <xs:element ref="Columns"/>
-            <xs:element ref="Region"/>
-            <xs:element ref="WindowWidth"/>
-            <xs:element ref="WindowCenter"/>
-            <xs:element ref="ImageQuality"/>
-            <xs:element ref="PresentationUID"/>
-            <xs:element ref="PresentationSeriesUID"/>
+            <xs:element ref="Annotation" minOccurs="0"/>
+            <xs:element ref="Rows" minOccurs="0"/>
+            <xs:element ref="Columns" minOccurs="0"/>
+            <xs:element ref="Region" minOccurs="0"/>
+            <xs:element ref="WindowWidth" minOccurs="0"/>
+            <xs:element ref="WindowCenter" minOccurs="0"/>
+            <xs:element ref="ImageQuality" minOccurs="0"/>
+            <xs:element ref="PresentationUID" minOccurs="0"/>
+            <xs:element ref="PresentationSeriesUID" minOccurs="0"/>
             <xs:element ref="Anonymize" minOccurs="0"/>
             <xs:element ref="ihe:Document"/>
             <xs:element ref="ihe:mimeType"/>


### PR DESCRIPTION
In the 6.4.2.2 RetrieveRenderedImagingDocumentResponse it is stated that these elements should be required. 
However it contradicts with chapter 8 Parameters of the Request:
- Annotation; This parameter is OPTIONAL for the URI based mode and the WS mode "Rendered Requester" transaction.
- Rows;  It is OPTIONAL for the URI based mode and the WS mode "Rendered Requester" transaction. 
- Columns; It is OPTIONAL for the URI based mode and the WS mode "Rendered Requester" transaction. 
- Region; The parameter is OPTIONAL for the URI based mode and the WS mode "Rendered Requester" transaction. 
- WindowWidth; This parameter is OPTIONAL for the URI based mode and the WS mode "Rendered Requester" transaction. 
- WindowCenter; This parameter is OPTIONAL for the URI based mode and the WS mode "Rendered Requester" transaction. 
- ImageQuality; It is OPTIONAL for the URI based mode and the WS mode "DICOM requester" and "Rendered Requester" transactions. 
- presentationUID; This parameter is OPTIONAL for the URI based mode and the WS mode "Rendered Requester" transaction. 
- PresentationSeriesUID; This parameter is REQUIRED and shall only be present if "presentationUID" is present.

If we make it required, then we need to think about sensible defaults. Because all of these are also optional on the request side.